### PR TITLE
fix: replace TGT_T compound assignment to avoid set -u crash

### DIFF
--- a/run-all.sh
+++ b/run-all.sh
@@ -57,7 +57,10 @@ if [[ -n "${TASKSET_BIN}" && "${CPU_CORES}" -ge 8 ]]; then
 fi
 
 # Throughput search upper bounds — RPS hint for binary-search; update after a reference run
-declare -A TGT_T=(['simple']=110500 ['complex']=67600 ['llm']=49400)
+declare -A TGT_T
+TGT_T[simple]=110500
+TGT_T[complex]=67600
+TGT_T[llm]=49400
 
 # Measured results (filled in at runtime)
 declare -A LAT_D LAT_P LAT_N


### PR DESCRIPTION
Companion to #3 / #5.

`declare -A TGT_T=(['simple']=... )` crashes with `simple: unbound variable` under `set -u` on some bash versions. Single-quoted keys in compound associative array assignments are not reliably handled across bash 4.x/5.x.

Fix: replace with unconditional separate statements which are unambiguous on all bash 4+ versions:

```bash
declare -A TGT_T
TGT_T[simple]=110500
TGT_T[complex]=67600
TGT_T[llm]=49400
```

`arr[key]=value` outside of a compound `()` assignment never triggers `$key` variable expansion under `set -u`.
