### PR TITLE
fix: daemonize nginx so it survives SSH session end in remote mode

### DIFF
--- a/run-all.sh
+++ b/run-all.sh
@@ -577,10 +577,10 @@ http {
   }
 }
 EOF
-    run_oresty_bg -p "${pfx}" -c "${pfx}/conf/nginx.conf" -g 'daemon off;' \
+    run_oresty_bg -p "${pfx}" -c "${pfx}/conf/nginx.conf" \
         >"${pfx}/logs/stdout.log" 2>"${pfx}/logs/stderr.log"
     _wait_port "${NGINX_PORT}" || {
-        warn "baseline nginx stderr:"; cat "${pfx}/logs/stderr.log" >&2
+        warn "baseline nginx error_log:"; cat "${pfx}/logs/error.log" >&2
         die "baseline nginx failed to start"
     }
     ok "Baseline nginx  :${NGINX_PORT}"
@@ -608,10 +608,10 @@ http {
   }
 }
 EOF
-    run_oresty_bg -p "${pfx}" -c "${pfx}/conf/nginx.conf" -g 'daemon off;' \
+    run_oresty_bg -p "${pfx}" -c "${pfx}/conf/nginx.conf" \
         >"${pfx}/logs/stdout.log" 2>"${pfx}/logs/stderr.log"
     _wait_port "${BACKEND_PORT}" || {
-        warn "backend nginx stderr:"; cat "${pfx}/logs/stderr.log" >&2
+        warn "backend nginx error_log:"; cat "${pfx}/logs/error.log" >&2
         die "backend nginx failed to start"
     }
     ok "Backend nginx    :${BACKEND_PORT}"
@@ -665,7 +665,7 @@ start_fairvisor() {
     done
 
     FAIRVISOR_CONFIG_FILE="${policy}" \
-    run_oresty_bg -p "${pfx}" -c "${pfx}/conf/nginx.conf" -g 'daemon off;' \
+    run_oresty_bg -p "${pfx}" -c "${pfx}/conf/nginx.conf" \
         >"${pfx}/logs/stdout.log" 2>"${pfx}/logs/stderr.log"
 
     _wait_port "${FV_PORT}" || {


### PR DESCRIPTION
Closes #11

## Root cause

`run_oresty_bg` starts OpenResty with `-g 'daemon off;'`, which means nginx runs as a **foreground child** of the bash process executing `run-all.sh`. When a helper sub-command (e.g. `helper-start baseline`) is invoked over SSH, it starts nginx, the function returns, the bash script exits — and the EXIT trap fires `_cleanup`, which kills every PID in `_BGPIDS` (including nginx). By the time k6 on the loadgen host runs, nginx is already dead, so every request gets connection-refused, producing `http_req_failed: 100%` and all-zero latencies.

## Fix

Remove `-g 'daemon off;'` from all three `run_oresty_bg` calls (`start_baseline`, `start_backend`, `start_fairvisor`). Without that flag nginx uses its default `daemon on` behaviour: it forks a daemonised master that is fully independent of the parent shell. The stored `_BGPIDS` entry refers to the short-lived forking parent (exits immediately); `_cleanup` tries to kill it, fails silently, and the real nginx daemon keeps running. Cleanup is handled by the `pkill -f openresty` already present in `helper_stop_all`.

## Verification

1. Manual test confirmed nginx on 8082 is unreachable from loadgen mid-run when `daemon off` is used.
2. After applying this fix locally, `k6` gets real latency numbers (p50≈226µs, 0% failure) against the same nginx.
